### PR TITLE
add missing details and routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,23 @@
 import React from 'react';
-import HomePage from './pages/HomePage';
+import { BrowserRouter, useRoutes } from 'react-router-dom';
+import { GalleryProvider } from './context/GalleryContext';
+import { AuthProvider } from './context/AuthContext';
+import { routes } from './routes';
+
+const AppRoutes: React.FC = () => {
+  const element = useRoutes(routes);
+  return element;
+};
+
 function App() {
   return (
-    <div className="min-h-screen bg-gray-100 flex items-center justify-center">
-      <HomePage />
-    </div>
+    <BrowserRouter>
+      <AuthProvider>
+        <GalleryProvider>
+          <AppRoutes />
+        </GalleryProvider>
+      </AuthProvider>
+    </BrowserRouter>
   );
 }
 

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+const MainLayout: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-gray-100">
+      {/* Add header, navigation, etc. here */}
+      <main className="container mx-auto px-4 py-8">
+        <Outlet />
+      </main>
+      {/* Add footer here */}
+    </div>
+  );
+};
+
+export default MainLayout; 

--- a/src/pages/ArtworkDetailPage.tsx
+++ b/src/pages/ArtworkDetailPage.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Heart, Share2, Edit, Trash2 } from 'lucide-react';
+import { ArrowLeft, Edit, Trash2 } from 'lucide-react';
 import { useGallery } from '../context/GalleryContext';
 import { useAuth } from '../context/AuthContext';
 
@@ -132,4 +132,22 @@ const ArtworkDetailPage: React.FC = () => {
                   ? isLiked 
                     ? 'bg-red-100 text-red-600' 
                     : 'bg-gray-100 text-gray-700 hover:bg-gray-200' 
-                  : 'bg-gray-100 text-gra
+                  : 'bg-gray-100 text-gray-700'
+              }`}
+            >
+              {isAuthenticated ? (isLiked ? 'Unlike' : 'Like') : 'Login to Like'}
+            </button>
+            <button 
+              onClick={handleShare}
+              className="flex items-center px-4 py-2 rounded-md bg-gray-100 text-gray-700 hover:bg-gray-200"
+            >
+              Share
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ArtworkDetailPage;

--- a/src/pages/GalleryDetailPage.tsx
+++ b/src/pages/GalleryDetailPage.tsx
@@ -11,7 +11,7 @@ const GalleryDetailPage: React.FC = () => {
   const gallery = galleries.find(g => g.id === id);
   
   useEffect(() => {
-    if (gallery) {
+    if (gallery?.tag) {
       setActiveTag(gallery.tag);
     }
     
@@ -19,7 +19,7 @@ const GalleryDetailPage: React.FC = () => {
       // Clear the filter when leaving the page
       setActiveTag(null);
     };
-  }, [gallery, setActiveTag]);
+  }, [gallery?.tag]);
   
   if (!gallery) {
     return (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,6 +3,7 @@ import { useGallery } from '../context/GalleryContext';
 import ArtworkCard from '../components/ArtworkCard';
 import SearchBar from '../components/SearchBar';
 import TagFilter from '../components/TagFilter';
+import { Link } from 'react-router-dom';
 
 const HomePage: React.FC = () => {
   const { filteredArtworks, galleries } = useGallery();
@@ -43,13 +44,13 @@ const HomePage: React.FC = () => {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {galleries.slice(0, 3).map(gallery => (
             <div key={gallery.id} className="bg-white rounded-lg shadow-md overflow-hidden">
-              <a href={`/gallery/${gallery.id}`} className="block">
+              <Link to={`/gallery/${gallery.id}`} className="block">
                 <div className="p-6">
                   <h3 className="text-xl font-semibold text-gray-900 mb-2">{gallery.title}</h3>
                   <p className="text-gray-600 mb-4">{gallery.description}</p>
                   <span className="text-indigo-600 font-medium">View Gallery →</span>
                 </div>
-              </a>
+              </Link>
             </div>
           ))}
         </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,0 +1,25 @@
+import { RouteObject } from 'react-router-dom';
+import MainLayout from '../layouts/MainLayout';
+import HomePage from '../pages/HomePage';
+import ArtworkDetailPage from '../pages/ArtworkDetailPage';
+import GalleryDetailPage from '../pages/GalleryDetailPage';
+
+export const routes: RouteObject[] = [
+  {
+    element: <MainLayout />,
+    children: [
+      {
+        path: '/',
+        element: <HomePage />,
+      },
+      {
+        path: '/artwork/:id',
+        element: <ArtworkDetailPage />,
+      },
+      {
+        path: '/gallery/:id',
+        element: <GalleryDetailPage />,
+      },
+    ],
+  },
+]; 


### PR DESCRIPTION
Bolt.new has a daily token limit which is a hard cutoff during code generation.
This meant that the context object created were not used, and routes were not defined.
In this PR I have added the providers and links to the detail pages.
The src/pages/ArtworkDetailPage.tsx was cut-off at the bottom as the limit was reached.
Still, good to see Stackblitz pivoting in a really important direction.

Code generation like this is the future of our jobs.